### PR TITLE
Update rgpluaclassbrowser.lua

### DIFF
--- a/rgpluaclassbrowser.lua
+++ b/rgpluaclassbrowser.lua
@@ -157,7 +157,7 @@ function update_list(list_control, source_table, search_text)
     local first_string = nil
     if type(source_table) == "table" then
         for k, v in pairsbykeys(source_table) do
-            if include_all or k:find(search_text) == 1 then
+            if include_all or string.find(string.lower(k), string.lower(search_text)) then
                 local fcstring = finale.FCString()
                 fcstring.LuaString = k
                 if type(v) == "table" then

--- a/rgpluaclassbrowser.lua
+++ b/rgpluaclassbrowser.lua
@@ -153,11 +153,13 @@ end
 
 function update_list(list_control, source_table, search_text)
     list_control:Clear()
-    local include_all = search_text == nil or search_text == ""
+    search_text = search_text or ""
+    local include_all = search_text == ""
+    local search_case_lower = string.lower(search_text)
     local first_string = nil
     if type(source_table) == "table" then
         for k, v in pairsbykeys(source_table) do
-            if include_all or string.find(string.lower(k), string.lower(search_text)) then
+            if include_all or string.find(string.lower(k), search_case_lower) then
                 local fcstring = finale.FCString()
                 fcstring.LuaString = k
                 if type(v) == "table" then


### PR DESCRIPTION
Add searching also by matching any part of the class name (method, etc.), and not just by the beginning.
search_text does not need to be checked for nil here because include_all precedes this one. It is desirable to move string.lower(search_text) outside the for loop, but then it is necessary to prevent a null argument for string.lower().